### PR TITLE
```admin.module View``` is not needed

### DIFF
--- a/Controller/TakeCustomerAccountController.php
+++ b/Controller/TakeCustomerAccountController.php
@@ -17,7 +17,6 @@ use Thelia\Controller\Admin\BaseAdminController;
 use Thelia\Core\Event\Customer\CustomerLoginEvent;
 use Thelia\Core\Event\TheliaEvents;
 use Thelia\Core\Security\AccessManager;
-use Thelia\Core\Security\Resource\AdminResources;
 use Thelia\Model\AdminLog;
 use Thelia\Model\CustomerQuery;
 
@@ -35,8 +34,7 @@ class TakeCustomerAccountController extends BaseAdminController
      */
     public function takeAction($customer_id)
     {
-        if (null !== $response = $this->checkAuth(array(
-                AdminResources::MODULE), 'TakeCustomerAccount', AccessManager::VIEW)) {
+        if (null !== $response = $this->checkAuth(array(), 'TakeCustomerAccount', AccessManager::VIEW)) {
             return $response;
         }
 


### PR DESCRIPTION
I don't understand why an admin user need the authorization of view configure modules list to for this action...
The same appears an lots of modules and for DELETE actions too
user need DELETE on configure modules list to delete something in the module...
