### PR TITLE
Fix bug with cart without currency

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <author>
         <name>Gilles Bourgeat</name>
         <email>gbourgeat@openstudio.fr</email>

--- a/EventListener/TakeCustomerAccountListener.php
+++ b/EventListener/TakeCustomerAccountListener.php
@@ -17,6 +17,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use TakeCustomerAccount\Event\TakeCustomerAccountEvent;
 use TakeCustomerAccount\Event\TakeCustomerAccountEvents;
 use TakeCustomerAccount\TakeCustomerAccount;
+use Thelia\Core\Event\Cart\CartCreateEvent;
 use Thelia\Core\Event\Customer\CustomerLoginEvent;
 use Thelia\Core\Event\DefaultActionEvent;
 use Thelia\Core\Event\TheliaEvents;
@@ -65,12 +66,13 @@ class TakeCustomerAccountListener implements EventSubscriberInterface
     {
         $this->eventDispatcher->dispatch(TheliaEvents::CUSTOMER_LOGOUT, new DefaultActionEvent());
 
-        $this->request->getSession()->getSessionCart($this->eventDispatcher)->clear();
-
         $this->eventDispatcher->dispatch(
             TheliaEvents::CUSTOMER_LOGIN,
             new CustomerLoginEvent($event->getCustomer())
         );
+
+        $newCartEvent = new CartCreateEvent();
+        $this->eventDispatcher->dispatch(TheliaEvents::CART_CREATE_NEW, $newCartEvent);
 
         AdminLog::append(
             TakeCustomerAccount::MODULE_DOMAIN,


### PR DESCRIPTION
The method clear on session cart erase all data even currency and in some case the currency is not seted normally and we have a cart without currency which cause bug when adding cart item.

Instead of clear cart I create new empty cart to replace the current cart.